### PR TITLE
Fix: x86-64 GRUB boot reset loop (Issue #23)

### DIFF
--- a/src/arch/x86_64/kernel_entry.asm
+++ b/src/arch/x86_64/kernel_entry.asm
@@ -100,9 +100,9 @@ setup_page_tables:
     mov al, '1'
     out dx, al
 
-    ; Zero tables (4 tables now: PML4, PDPT, PD, PT_KERNEL)
+    ; Zero tables (5 tables now: PML4, PDPT, PD, PT_KERNEL, PT_KERNEL2)
     mov edi, pml4_table
-    mov ecx, (4096 * 4) / 4
+    mov ecx, (4096 * 5) / 4
     xor eax, eax
     rep stosd
 
@@ -124,30 +124,49 @@ setup_page_tables:
     mov dword [pdpt_table + 4], 0
 
     ; PD[0] -> PT_KERNEL (first 2MB, contains kernel at 1MB)
-    ; This gives us fine-grained 4KB control over kernel region
+    ; PD[1] -> PT_KERNEL2 (next 2MB, contains .data/.bss sections)
+    ; This gives us fine-grained 4KB control over kernel region (0-4MB)
     mov eax, pt_kernel
     or eax, 0x3                     ; Present + Writable
     mov [pd_table], eax
     mov dword [pd_table + 4], 0
+
+    mov eax, pt_kernel2
+    or eax, 0x3                     ; Present + Writable
+    mov [pd_table + 8], eax
+    mov dword [pd_table + 12], 0
 
     ; Debug: Mapping 4KB pages
     mov dx, 0xE9
     mov al, '3'
     out dx, al
 
-    ; Map first 2MB using 4KB pages via PT_KERNEL
-    ; This covers 0x000000 - 0x200000 (includes kernel at 0x100000)
-    mov ecx, 512                    ; 512 entries * 4KB = 2MB
+    ; Map first 4MB using 4KB pages via PT_KERNEL and PT_KERNEL2
+    ; This covers 0x000000 - 0x400000 (includes kernel + data + bss)
+    mov ecx, 1024                   ; 1024 entries * 4KB = 4MB
     xor eax, eax
 .map_4kb_loop:
     mov edx, eax
     shl edx, 12                     ; Physical address = index * 4KB
     mov ebx, edx
     or ebx, 0x03                    ; Present + Writable (4KB pages)
+
+    ; First 512 entries go to PT_KERNEL, next 512 to PT_KERNEL2
+    cmp eax, 512
+    jl .first_table
+    ; PT_KERNEL2 (entries 512-1023)
+    mov esi, eax
+    sub esi, 512
+    mov [pt_kernel2 + esi*8], ebx
+    mov dword [pt_kernel2 + esi*8 + 4], 0
+    jmp .next_entry
+.first_table:
+    ; PT_KERNEL (entries 0-511)
     mov [pt_kernel + eax*8], ebx
     mov dword [pt_kernel + eax*8 + 4], 0
+.next_entry:
     inc eax
-    cmp eax, 512
+    cmp eax, 1024
     jl .map_4kb_loop
 
     ; Debug: Mapping 2MB pages
@@ -155,9 +174,9 @@ setup_page_tables:
     mov al, '4'
     out dx, al
 
-    ; Map 2MB-1GB using 2MB pages (entries 1-511 in PD)
-    mov ecx, 511                    ; 511 entries (skip entry 0, already mapped)
-    mov eax, 1                      ; Start at index 1
+    ; Map 4MB-1GB using 2MB pages (entries 2-511 in PD)
+    mov ecx, 510                    ; 510 entries (skip entries 0-1, already mapped)
+    mov eax, 2                      ; Start at index 2
 .map_2mb_loop:
     mov edx, eax
     shl edx, 21                     ; Physical address = index * 2MB
@@ -314,6 +333,9 @@ pd_table:
     resb 4096
 align 4096
 pt_kernel:
+    resb 4096
+align 4096
+pt_kernel2:
     resb 4096
 
 align 16


### PR DESCRIPTION
## Summary
- Fixed x86-64 kernel continuous reset loop when booted via GRUB/multiboot2
- Extended page table mapping from 2MB to 4MB to cover .data/.bss sections
- Kernel now successfully boots and initializes all phases

## Problem
The kernel was experiencing infinite resets when calling `kernel_main()` during GRUB boot. Debug output showed successful entry into kernel_main but reset when accessing .data/.bss sections around 0x167000.

## Root Cause
Page tables only mapped first 2MB (0x0-0x200000), but .bss section extends beyond this range. Accessing unmapped memory caused:
- Page fault → Triple fault → CPU reset → Boot loop

## Solution
Extended page table coverage to 4MB by:
1. Added `PT_KERNEL2` page table for 2MB-4MB range
2. Updated page directory entries PD[0] and PD[1]
3. Modified mapping loop to create 1024 4KB pages (was 512)
4. Adjusted 2MB page mapping to start at index 2 (was 1)

## Changes
**Modified:** `src/arch/x86_64/kernel_entry.asm`
- Extended page table allocation from 4 tables to 5 tables
- Added PT_KERNEL2 in BSS section
- Updated setup_page_tables to map 0-4MB with 4KB pages
- Adjusted 2MB mapping range from 4MB-1GB

## Testing Results
**Before fix:**
- Reset loop at kernel_main call
- Debug pattern: `12345ABPCDEFG` repeating indefinitely

**After fix:**
- ✅ Kernel boots successfully past kernel_main
- ✅ Memory subsystem initializes  
- ✅ All kernel phases (1-5) initialize
- ✅ No more reset loop
- ⚠️ New issue discovered at FD init (likely existing Issue #21)

## Impact
- **+32 lines, -10 lines** in kernel_entry.asm
- Resolves pre-existing infrastructure issue from Issue #20 testing
- Enables x86-64 development and testing to proceed
- No impact on ARM64 (architecture-specific change)

## Related Issues
- Fixes #23
- Discovered during testing for #20
- Unmasks existing #21 (kmalloc crash, separate issue)